### PR TITLE
fix: correct dryer card heading

### DIFF
--- a/lovelace/cards/laundry/dryer.yaml
+++ b/lovelace/cards/laundry/dryer.yaml
@@ -4,7 +4,7 @@ cards:
 # Dryer Column
 - type: heading
   heading_style: title
-  heading: "Drier Monitor"
+  heading: "Dryer Monitor"
   badges:
     - type: entity
       entity: input_boolean.dryer_on


### PR DESCRIPTION
## Summary
- fix minor typo in dryer card heading

## Testing
- `grep -n "Dryer Monitor" lovelace/cards/laundry/dryer.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685f65e10128832cac0de633da7df4d4